### PR TITLE
[INFRA-3157] use Clever fork of yaml library to avoid 80-character output line limit

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,7 +9,8 @@ import (
 	"strings"
 
 	"github.com/Clever/circle-v2-migrate/models"
-	yaml "gopkg.in/yaml.v2"
+	// use Clever fork of go-yaml/yaml because go-yaml/yaml limits lines to 80 characters
+	"github.com/Clever/yaml"
 )
 
 const GOLANG_APP_TYPE = "go"
@@ -44,6 +45,7 @@ func main() {
 	} else {
 		fmt.Println(string(marshalled))
 	}
+
 	fmt.Println("----------------------------------------")
 
 	// @TODO (INFRA-3158): after translation, write marshalled YAML to .circleci/config.yml
@@ -170,7 +172,6 @@ func translateTestSteps(v1 *models.CircleYamlV1, v2 *models.CircleYamlV2) {
 	}
 }
 
-// @TODO (INFRA-3157): remove line breaks in deploy steps -- they break dapple deploy, for instance
 func translateDeploySteps(v1 *models.CircleYamlV1, v2 *models.CircleYamlV2) error {
 	for key := range v1.Deployment {
 		if key != "master" && key != "non-master" {


### PR DESCRIPTION
**JIRA**: [INFRA-3157](https://clever.atlassian.net/browse/INFRA-3157)

**Overview**
The YAML library we were using imposes an 80-character line limit on marshalled output; it adds a line break in the middle of longer lines.  We need to be able to accurately translate lines that exceed this 80 character limit, like:

```
- $HOME/ci-scripts/circleci/dapple-deploy $DAPPLE_URL $DAPPLE_USER $DAPPLE_PASS $APP_NAME production confirm-then-deploy
```

Clever already forked the YAML library in question and made this change, so this PR has `circle-v2-migrate` use the fork instead of the upstream library.

**Old output with previous library:**
```
    - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/dapple-deploy
        $DAPPLE_URL $DAPPLE_USER $DAPPLE_PASS $APP_NAME production confirm-then-deploy;
        fi;
```

Too many lines! CircleCI can't tell that the `$DAPPLE_` vars are arguments for the `dapple-deploy` script!

**New output using Clever fork:**
```
    - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/dapple-deploy $DAPPLE_URL $DAPPLE_USER $DAPPLE_PASS $APP_NAME production confirm-then-deploy; fi;
```
Single line! Clearly all part of one command!