### PR TITLE
[INFRA-3158] update file format for translation

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,8 +46,22 @@ func main() {
 	}
 	fmt.Println("----------------------------------------")
 
-	// @TODO (INFRA-3158): after translation, write marshalled YAML to .circleci/config.yml
-	// @TODO (INFRA-3158): after translation, remove or rename circle.yml
+	// after translation, write marshalled YAML to .circleci/config.yml
+	if _, err := os.Stat("./.circleci"); err != nil {
+		os.Mkdir("./.circleci", os.ModePerm)
+	}
+	outFile, err := os.Create("./.circleci/config.yml")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("writing circleci 2.0 config to .circleci/config.yml")
+	_, err = outFile.Write(marshalled)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// after translation, remove or rename circle.yml
+	fmt.Println("renaming circle.yml -> circle.yml.bak")
+	os.Rename("./circle.yml", "./circle.yml.bak")
 }
 
 // readCircleYaml reads and parses the repo's circle.yml (V1) file


### PR DESCRIPTION
To support using this script with microplane, we need to update file structure instead of just printing output. 

This PR makes it so that after translation, we:
- write the new CircleCI 2.0 config to `.circleci/config.yml` so it'll trigger a CircleCI 2.0 build, and
- rename `circle.yml` (the CircleCI 1.0 config) to `circle.yml.bak` to avoid confusion.

At a later point, we can remove `circle.yml.bak` completely. Right now, it's nice to have around for testing improvements to the migration script. 