### PR TITLE
[INFRA-3159] add initial database support for mongodb and postgresql

### DIFF
--- a/main.go
+++ b/main.go
@@ -424,44 +424,39 @@ func determineNodeVersion() string {
 	return version
 }
 
-func getImage(constraints models.ImageConstraints) string {
+func getImage(constraints models.ImageConstraints) models.DockerImage {
 	// @TODO (INFRA-3163): add human-readable image tags/other comments for image, if doable in yaml
+	// @TODO: use SHAs for all images
 	appType := constraints.AppType
 	version := constraints.Version
 	// default image (reproduces CircleCI 1.0 base)
-	defaultImage := "circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37"
-	if appType == GOLANG_APP_TYPE {
-		// @TODO (INFRA-3149): base image for go and wag 1.8 or earlier that's not just the xxl default?
-		if version == "1.10" {
-			// circleci/golang:1.10.3-stretch
-			// return "circleci/golang@sha256:4614481a383e55eef504f26f383db1329c285099fde0cfd342c49e5bb9b6c32a"
-			return "circleci/golang:1.10.3-stretch"
-		} else if version == "1.9" {
-			// circleci/golang:1.9.7-stretch
-			// return "circleci/golang@sha256:c46bee0b60747525d354f219083a46e06c68152f90f3bfb2812d1f232e6a5097"
-			return "circleci/golang:1.9.7-stretch"
-		}
-	} else if appType == WAG_APP_TYPE {
-		// @TODO (INFRA-3149): node version for wag locked in at 8.11.3 by these images -- could be ok (?)
-		// @TODO (INFRA-3149): base image for node <6 that's not just the xxl default?
-		if version == "1.10" {
-			// circleci/golang:1.10.3-stretch
-			// return "circleci/golang@sha256:4614481a383e55eef504f26f383db1329c285099fde0cfd342c49e5bb9b6c32a"
-			return "circleci/golang:1.10.3-stretch"
-		} else if version == "1.9" {
-			// circleci/golang:1.9.7-stretch
-			// return "circleci/golang@sha256:c46bee0b60747525d354f219083a46e06c68152f90f3bfb2812d1f232e6a5097"
-			return "circleci/golang:1.9.7-stretch"
+	defaultImage := models.DockerImage{
+		Image: "circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37",
+	}
+
+	// @TODO (INFRA-3149): node version for wag locked in at 8.11.3 by these images -- could be ok (?)
+	golangImageMap := map[string]models.DockerImage{
+		"1.10": models.DockerImage{Image: "circleci/golang:1.10.3-stretch"}, // "circleci/golang@sha256:4614481a383e55eef504f26f383db1329c285099fde0cfd342c49e5bb9b6c32a"
+		"1.9":  models.DockerImage{Image: "circleci/golang:1.9.7-stretch"},  // "circleci/golang@sha256:c46bee0b60747525d354f219083a46e06c68152f90f3bfb2812d1f232e6a5097"
+		"1.8":  models.DockerImage{Image: "circleci/golang:1.8.7-stretch"},
+	}
+
+	// @TODO (INFRA-3149): base image for node <6 that's not just the xxl default?
+	nodeImageMap := map[string]models.DockerImage{
+		"10": models.DockerImage{Image: "circleci/node:10.8.0-stretch"},
+		"8":  models.DockerImage{Image: "circleci/node:8.11.3-stretch"},
+		"6":  models.DockerImage{Image: "circleci/node:6.14.3-stretch"},
+	}
+
+	if appType == GOLANG_APP_TYPE || appType == WAG_APP_TYPE {
+		golangBaseImage, ok := golangImageMap[version]
+		if ok {
+			return golangBaseImage
 		}
 	} else if appType == NODE_APP_TYPE {
-		if version == "10" {
-			return "circleci/node:10.8.0-stretch"
-		} else if version == "8" {
-			// circleci/node:8.11.3-stretch
-			return "circleci/node:8.11.3-stretch"
-		} else if version == "6" {
-			// circleci/node:6.14.3-stretch
-			return "circleci/node:6.14.3-stretch"
+		nodeBaseImage, ok := nodeImageMap[version]
+		if ok {
+			return nodeBaseImage
 		}
 	}
 	fmt.Printf("No circleci image selected for app type %s, version %s -- using default\n", constraints.AppType, constraints.Version)

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ const POSTGRESQL_DB_TYPE = "postgresql"
 // https://circleci.com/docs/2.0/migrating-from-1-2/
 
 // @TODO: add info about target repo (e.g., name) to log lines (kayvee?)
+// @TODO: breaks for mongo-to-s3, which uses golang-move-repo ci-scripts script :(
 func main() {
 	v1, err := readCircleYaml()
 	if err != nil {
@@ -36,18 +37,12 @@ func main() {
 		log.Fatal(err)
 	}
 
-	fmt.Println("V1")
-	fmt.Println(v1)
-
-	fmt.Println("V2")
-	fmt.Println(v2)
-
 	fmt.Println("---------- circle YAML Preview ---------")
 	marshalled, err := yaml.Marshal(v2)
 	if err != nil {
 		fmt.Printf("Failed to Marshal v2 yml:\n %s", err)
 	} else {
-		fmt.Println(string(marshalled))
+		// fmt.Println(string(marshalled))
 	}
 
 	fmt.Println("----------------------------------------")
@@ -351,6 +346,10 @@ func determineWorkingDirectory(appType string) (string, error) {
 	return fmt.Sprintf("~/Clever/%s", repo), nil
 }
 
+// determineImageConstraints returns the constraints for the docker images section of build, including:
+// -- app type (wag, go, node, unknown)
+// -- version of  image base language/library (e.g., go "1.10", node "6")
+// -- database types needed for tests (e.g., mongo, postgresql)
 func determineImageConstraints() models.ImageConstraints {
 	// if node, will have package.json and node.mk (but this is clever-specific) in main project dir
 	// if go, will have golang.mk (but this is clever-specific)
@@ -463,6 +462,7 @@ func determineNodeVersion() string {
 	return version
 }
 
+// getImage returns the primary image needed for a repo to build, based on app type and version
 func getImage(constraints models.ImageConstraints) models.DockerImage {
 	// @TODO (INFRA-3163): add human-readable image tags/other comments for image, if doable in yaml
 	// @TODO: use SHAs for all images

--- a/main.go
+++ b/main.go
@@ -14,6 +14,8 @@ import (
 	"github.com/Clever/yaml"
 )
 
+const SCRIPT_VERSION = "0.1.0"
+
 const GOLANG_APP_TYPE = "go"
 const NODE_APP_TYPE = "node"
 const WAG_APP_TYPE = "wag"
@@ -27,6 +29,7 @@ const POSTGRESQL_DB_TYPE = "postgresql"
 // @TODO: add info about target repo (e.g., name) to log lines (kayvee?)
 // @TODO: breaks for mongo-to-s3, which uses golang-move-repo ci-scripts script :(
 func main() {
+	fmt.Printf("circle-v2-migrate v%s\n", SCRIPT_VERSION)
 	v1, err := readCircleYaml()
 	if err != nil {
 		log.Fatal(err)
@@ -37,7 +40,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	fmt.Println("---------- circle YAML Preview ---------")
+	// fmt.Println("---------- circle YAML Preview ---------")
 	marshalled, err := yaml.Marshal(v2)
 	if err != nil {
 		fmt.Printf("Failed to Marshal v2 yml:\n %s", err)
@@ -45,7 +48,7 @@ func main() {
 		// fmt.Println(string(marshalled))
 	}
 
-	fmt.Println("----------------------------------------")
+	// fmt.Println("----------------------------------------")
 
 	// after translation, write marshalled YAML to .circleci/config.yml
 	if _, err := os.Stat("./.circleci"); err != nil {
@@ -393,6 +396,7 @@ func determineDatabaseTypes() map[string]struct{} {
 // -- true if a Makefile contains the text `psql`
 // -- false otherwise
 func needsPostgreSQL() bool {
+	// @TODO: could also check for pq in Gopkg.toml, for go repos -- but does this always mean it's used in tests?
 	postgresqlCheckRegexp := regexp.MustCompile(`psql`)
 	makefile, err := ioutil.ReadFile("Makefile")
 	if err != nil {
@@ -406,6 +410,7 @@ func needsPostgreSQL() bool {
 // -- true if a file with `test` in the name contains the text `testMongoURL`
 // -- false otherwise
 func needsMongoDB() bool {
+	// @TODO: could also check for mgo in Gopkg.toml, for go repos -- but does this always mean it's used in tests?
 	// check Makefile for MONGO_TEST_DB
 	mongoCheckRegexp := regexp.MustCompile(`MONGO_TEST_DB`)
 	makefile, err := ioutil.ReadFile("Makefile")

--- a/main.go
+++ b/main.go
@@ -341,6 +341,10 @@ func determineWorkingDirectory(appType string) (string, error) {
 		return "", fmt.Errorf("failed to find repo in %s", dir)
 	}
 	repo := splitDir[len(splitDir)-1]
+	// for microplane compaibility:
+	if repo == "planned" {
+		repo = splitDir[len(splitDir)-3]
+	}
 
 	// put together working directory string
 	if appType == GOLANG_APP_TYPE || appType == WAG_APP_TYPE {

--- a/main.go
+++ b/main.go
@@ -131,9 +131,6 @@ func convertToV2(v1 models.CircleYamlV1) (models.CircleYamlV2, error) {
 		}
 	}
 
-	// Install awscli for ECR interactions (used in docker publish steps)
-	addInstallAWSCLIStep(&v2)
-
 	// Create directories that were automatically created in CircleCI 1.0
 	addCreateCIArtifactDirsStep(&v2)
 
@@ -145,15 +142,18 @@ func convertToV2(v1 models.CircleYamlV1) (models.CircleYamlV2, error) {
 		addNPMInstallStep(&v2)
 	}
 
-	// @TODO: includes is not actually a thing. swith databaseTypes to map[string]struct{}
 	_, usesPostgresql := imageConstraints.DatabaseTypes[POSTGRESQL_DB_TYPE]
 	if usesPostgresql {
 		addInstallPSQLStep(&v2)
 		addWaitForPostgresStep(&v2)
 	}
+
 	// translate COMPILE & TEST steps
 	translateCompileSteps(&v1, &v2)
 	translateTestSteps(&v1, &v2)
+
+	// Install awscli for ECR interactions (used in docker publish deployment steps)
+	addInstallAWSCLIStep(&v2)
 
 	// translate and deduplicate DEPLOYMENT steps on master and non-master branches
 	err = translateDeploySteps(&v1, &v2)

--- a/main.go
+++ b/main.go
@@ -416,12 +416,14 @@ func needsPostgreSQL() bool {
 func needsMongoDB() bool {
 	// @TODO: could also check for mgo in Gopkg.toml, for go repos -- but does this always mean it's used in tests?
 	// check Makefile for MONGO_TEST_DB
-	mongoCheckRegexp := regexp.MustCompile(`MONGO_TEST_DB`)
+	// @TODO update comment; use "or" in regexp
+	mongoCheckRegexp1 := regexp.MustCompile(`MONGO_TEST_DB`)
+	mongoCheckRegexp2 := regexp.MustCompile(`mongodb://localhost`)
 	makefile, err := ioutil.ReadFile("Makefile")
 	if err != nil {
 		log.Fatal(err)
 	}
-	if mongoCheckRegexp.Match(makefile) {
+	if mongoCheckRegexp1.Match(makefile) || mongoCheckRegexp2.Match(makefile) {
 		return true
 	}
 	// check test files for testMongoURL

--- a/models/translation.go
+++ b/models/translation.go
@@ -2,6 +2,7 @@ package models
 
 // types for translations
 type ImageConstraints struct {
-	AppType string
-	Version string
+	AppType       string
+	Version       string
+	DatabaseTypes map[string]struct{}
 }


### PR DESCRIPTION
**JIRA:** [INFRA-3159](https://clever.atlassian.net/browse/INFRA-3159)

This is probably easier to review commit-by-commit. 

Overall, for databases, **this PR adds initial postgresql and mongo support:**
- for postgresql example, see `redshift-respawn` repo's [build](https://circleci.com/gh/Clever/redshift-respawn/1172) and [code change](https://github.com/Clever/redshift-respawn/pull/662/files) from this script
- for mongo example, see `il-config-service` repo's [build](https://github.com/Clever/il-config-service/pull/90) and [code change](https://circleci.com/gh/Clever/il-config-service/347/files) from this script

There are a few different ways to use databases with CircleCI 2.0 builds; this PR uses includes databases in additional docker images after the primary docker image.

To detect database use in tests, the code just looks for specific phrases in specific files. The example repos might not cover *all* of the ways postgres or mongo are included in tests, so it's likely we'll have to expand how we look for databases in later iterations.

Unrelated to databases, **this PR also includes some refactoring and cleanup:**
- refactors `getImage` for primary image to use maps
- moves `awscli` install step later in the build since it's generally not needed for tests
- adds some comments