### PR TITLE
[WIP][INFRA-3169] also look for postgres in circle.yml

### DIFF
--- a/main.go
+++ b/main.go
@@ -423,7 +423,15 @@ func needsPostgreSQL() bool {
 	if err != nil {
 		log.Fatal(err)
 	}
-	return postgresqlCheckRegexp.Match(makefile)
+	postgresqlCircleCheckRegexp := regexp.MustCompile(`postgres`)
+	circleYAML, err := ioutil.ReadFile("circle.yml")
+	if err != nil {
+		circleYAML, err = ioutil.ReadFile("circle.yml.bak")
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+	return postgresqlCheckRegexp.Match(makefile) || postgresqlCircleCheckRegexp.Match(circleYAML)
 }
 
 // needsMongoDB returns true if tests rely on mongodb, based on these criteria:


### PR DESCRIPTION
JIRA: [INFRA-3169](https://clever.atlassian.net/browse/INFRA-3169)

Many DEIP repos don't have `psql` in their makefile but do use postgres in the circle process. These seem to still mention `postgres` in circle.yml, so adding that check. 

Sample build before:
Sample build after: 